### PR TITLE
Fix build_gif interval

### DIFF
--- a/session-2/libs/gif.py
+++ b/session-2/libs/gif.py
@@ -53,7 +53,7 @@ def build_gif(imgs, interval=0.1, dpi=72,
             ax.imshow(x)], imgs))
 
     ani = animation.ArtistAnimation(
-        fig, axs, interval=interval, repeat_delay=0, blit=False)
+        fig, axs, interval=interval*1000, repeat_delay=0, blit=False)
 
     if save_gif:
         try:

--- a/session-3/libs/gif.py
+++ b/session-3/libs/gif.py
@@ -53,7 +53,7 @@ def build_gif(imgs, interval=0.1, dpi=72,
             ax.imshow(x)], imgs))
 
     ani = animation.ArtistAnimation(
-        fig, axs, interval=interval, repeat_delay=0, blit=False)
+        fig, axs, interval=interval*1000, repeat_delay=0, blit=False)
 
     if save_gif:
         ani.save(saveto, writer='imagemagick', dpi=dpi)


### PR DESCRIPTION
animation interval must be milliseconds; given the build_gif documented parameter in seconds, it should be converted in equivalent unit, i.e. multiplied by 1000.