### PR TITLE
Fix missing control_flow_ops import error

### DIFF
--- a/session-3/libs/batch_norm.py
+++ b/session-3/libs/batch_norm.py
@@ -3,7 +3,7 @@ Parag K. Mital, Jan 2016.
 """
 
 import tensorflow as tf
-from tensorflow.python import control_flow_ops
+from tensorflow.python.ops import control_flow_ops
 
 
 def batch_norm(x, phase_train, name='bn', decay=0.99, reuse=None, affine=True):


### PR DESCRIPTION
control_flow_ops is currently available under tensorflow.python.ops. This fixes:

ImportError: cannot import name 'control_flow_ops'