### PR TITLE
Fix typo session-4.ipynb

### DIFF
--- a/session-4/session-4.ipynb
+++ b/session-4/session-4.ipynb
@@ -339,9 +339,9 @@
     "<a name=\"a-note-on-1x1-convolutions\"></a>\n",
     "## A Note on 1x1 Convolutions\n",
     "\n",
-    "The 1x1 convolutions are setting the `ksize` parameter of the kernels to 1.  This is effectively allowing you to change the number of dimensions.  Remember that you need a 4-d tensor as input to a convolution.  Let's say its dimensions are $\\text{N}\\ x\\ \\text{W}\\ x\\ \\text{H}\\ x\\ \\text{C}_I$, where $\\text{C}_I$ represents the number of channels the image has.  Let's say it is an RGB image, then $\\text{C}_I$ would be 3.  Or later in the network, if we have already convolved it, it might be 64 channels instead.  Regardless, when you convolve it w/ a $\\text{K}_H\\ x\\ \\text{K}_W\\ x\\ \\text{C}_I\\ x\\ \\text{C}_O$ filter, where $\\text{K}_H$ is 1 and $\\text{K}_W$ is also 1, then the filters size is: $1\\ x\\ 1\\ x\\ \\text{C}_I$ and this is perfomed for each output channel $\\text{C}_O$.  What this is doing is filtering the information only in the channels dimension, not the spatial dimensions.  The output of this convolution will be a $\\text{N}\\ x\\ \\text{W}\\ x\\ \\text{H}\\ x\\ \\text{C}_O$ output tensor.  The only thing that changes in the output is the number of output filters.\n",
+    "The 1x1 convolutions are setting the `ksize` parameter of the kernels to 1.  This is effectively allowing you to change the number of dimensions.  Remember that you need a 4-d tensor as input to a convolution.  Let's say its dimensions are $\\text{N}\\ x\\ \\text{H}\\ x\\ \\text{W}\\ x\\ \\text{C}_I$, where $\\text{C}_I$ represents the number of channels the image has.  Let's say it is an RGB image, then $\\text{C}_I$ would be 3.  Or later in the network, if we have already convolved it, it might be 64 channels instead.  Regardless, when you convolve it w/ a $\\text{K}_H\\ x\\ \\text{K}_W\\ x\\ \\text{C}_I\\ x\\ \\text{C}_O$ filter, where $\\text{K}_H$ is 1 and $\\text{K}_W$ is also 1, then the filters size is: $1\\ x\\ 1\\ x\\ \\text{C}_I$ and this is perfomed for each output channel $\\text{C}_O$.  What this is doing is filtering the information only in the channels dimension, not the spatial dimensions.  The output of this convolution will be a $\\text{N}\\ x\\ \\text{H}\\ x\\ \\text{W}\\ x\\ \\text{C}_O$ output tensor.  The only thing that changes in the output is the number of output filters.\n",
     "\n",
-    "The 1x1 convolution operation is essentially reducing the amount of information in the channels dimensions before performing a much more expensive operation, e.g. a 3x3 or 5x5 convolution.  Effectively, it is a very clever trick for dimensionality reduction used in many state of the art convolutional networks.  Another way to look at it is that it is preseving the spatial information, but at each location, there is a fully connected network taking all the information from every input channel, $\\text{C}_I$, and reducing it down to $\\text{C}_O$ channels (or could easily also be up, but that is not the typical use case for this).  So it's not really a convolution, but we can use the convolution operation to perform it at every location in our image.\n",
+    "The 1x1 convolution operation is essentially reducing the amount of information in the channels dimensions before performing a much more expensive operation, e.g. a 3x3 or 5x5 convolution.  Effectively, it is a very clever trick for dimensionality reduction used in many state of the art convolutional networks.  Another way to look at it is that it is preserving the spatial information, but at each location, there is a fully connected network taking all the information from every input channel, $\\text{C}_I$, and reducing it down to $\\text{C}_O$ channels (or could easily also be up, but that is not the typical use case for this).  So it's not really a convolution, but we can use the convolution operation to perform it at every location in our image.\n",
     "\n",
     "If you are interested in reading more about this architecture, I highly encourage you to read [Network in Network](https://arxiv.org/pdf/1312.4400v3.pdf), Christian Szegedy's work on the [Inception network](http://www.cs.unc.edu/~wliu/papers/GoogLeNet.pdf), Highway Networks, Residual Networks, and Ladder Networks.\n",
     "\n",
@@ -422,7 +422,7 @@
     "\n",
     "# And here is a context manager.  We use the python \"with\" notation to create a context\n",
     "# and create a session that only exists within this indent,  as soon as we leave it,\n",
-    "# the session is automatically closed!  We also tel the session which graph to use.\n",
+    "# the session is automatically closed!  We also tell the session which graph to use.\n",
     "# We can pass a second context after the comma,\n",
     "# which we'll use to be explicit about using the CPU instead of a GPU.\n",
     "with tf.Session(graph=g) as sess, g.device(device):\n",
@@ -537,7 +537,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's try this w/ an image now.  We're going to use the `plot_gradient` function to help us.  This is going to take our input image, run it through the network up to a layer, find the gradient of the mean of that layer's activation with respect to the input image, then backprop that gradient back to the input layer.  We'll then visualize the gradient by normalizing it's values using the `utils.normalize` function."
+    "Let's try this w/ an image now.  We're going to use the `plot_gradient` function to help us.  This is going to take our input image, run it through the network up to a layer, find the gradient of the mean of that layer's activation with respect to the input image, then backprop that gradient back to the input layer.  We'll then visualize the gradient by normalizing its values using the `utils.normalize` function."
    ]
   },
   {
@@ -1045,7 +1045,7 @@
     "<a name=\"guided-hallucinations\"></a>\n",
     "## Guided Hallucinations\n",
     "\n",
-    "Instead of following the gradient of an arbitrary mean or max of a particular layer's activation, or a particular object that we want to synthesize, we can also try to guide our image to look like another image.  One way to try this is to take one image, the guide, and find the features at a particular layer or layers.  Then, we take our synthesis image and find the gradient which makes it's own layers activations look like the guide image.\n",
+    "Instead of following the gradient of an arbitrary mean or max of a particular layer's activation, or a particular object that we want to synthesize, we can also try to guide our image to look like another image.  One way to try this is to take one image, the guide, and find the features at a particular layer or layers.  Then, we take our synthesis image and find the gradient which makes its own layers activations look like the guide image.\n",
     "\n",
     "<h3><font color='red'>TODO! COMPLETE THIS SECTION!</font></h3>"
    ]


### PR DESCRIPTION
The crucial change is the order of the shape `NHWC` instead of `NWHC`.