### PR TITLE
Update utils.py

### DIFF
--- a/session-1/libs/utils.py
+++ b/session-1/libs/utils.py
@@ -110,7 +110,8 @@ def get_celeb_files():
 
     files = [os.path.join('img_align_celeba', file_i)
              for file_i in os.listdir('img_align_celeba')
-             if '.jpg' in file_i]
+             if ('.jpg' in file_i) and (file_i < '000101.jpg')]
+    
     return files
 
 


### PR DESCRIPTION
This change limits  get_celeb_files to return a maximum of 100 files when the directory 'img_align_celeba' already exists with more than 100 files. The full data-set is over 200,000 files. This code still relies on the files being sequential and in the format '000%03d' which is the original format. Where files are missing, the number of returned files will less than 100.

Note: a future recommendation is to pass a file_quantity parameter to get_celeb_imgs to allow for data-sets  of any size.