### PR TITLE
Noise ignored in denoising VAE

### DIFF
--- a/session-3/libs/vae.py
+++ b/session-3/libs/vae.py
@@ -94,11 +94,11 @@ def VAE(input_shape=[None, 784],
     keep_prob = tf.placeholder(tf.float32, name='keep_prob')
     corrupt_prob = tf.placeholder(tf.float32, [1])
 
-    if denoising:
-        current_input = utils.corrupt(x) * corrupt_prob + x * (1 - corrupt_prob)
+    # apply noise if denoising
+    x_ = (utils.corrupt(x) * corrupt_prob + x * (1 - corrupt_prob)) if denoising else x
 
     # 2d -> 4d if convolution
-    x_tensor = utils.to_tensor(x) if convolutional else x
+    x_tensor = utils.to_tensor(x_) if convolutional else x_
     current_input = x_tensor
 
     Ws = []

--- a/session-4/libs/vae.py
+++ b/session-4/libs/vae.py
@@ -94,11 +94,11 @@ def VAE(input_shape=[None, 784],
     keep_prob = tf.placeholder(tf.float32, name='keep_prob')
     corrupt_prob = tf.placeholder(tf.float32, [1])
 
-    if denoising:
-        current_input = utils.corrupt(x) * corrupt_prob + x * (1 - corrupt_prob)
+    # apply noise if denoising
+    x_ = (utils.corrupt(x) * corrupt_prob + x * (1 - corrupt_prob)) if denoising else x
 
     # 2d -> 4d if convolution
-    x_tensor = utils.to_tensor(x) if convolutional else x
+    x_tensor = utils.to_tensor(x_) if convolutional else x_
     current_input = x_tensor
 
     Ws = []

--- a/session-5/libs/vae.py
+++ b/session-5/libs/vae.py
@@ -94,11 +94,11 @@ def VAE(input_shape=[None, 784],
     keep_prob = tf.placeholder(tf.float32, name='keep_prob')
     corrupt_prob = tf.placeholder(tf.float32, [1])
 
-    if denoising:
-        current_input = utils.corrupt(x) * corrupt_prob + x * (1 - corrupt_prob)
+    # apply noise if denoising
+    x_ = (utils.corrupt(x) * corrupt_prob + x * (1 - corrupt_prob)) if denoising else x
 
     # 2d -> 4d if convolution
-    x_tensor = utils.to_tensor(x) if convolutional else x
+    x_tensor = utils.to_tensor(x_) if convolutional else x_
     current_input = x_tensor
 
     Ws = []


### PR DESCRIPTION
This PR handles #56 by replacing

```
if denoising:
    current_input = utils.corrupt(x) * corrupt_prob + x * (1 - corrupt_prob)

# 2d -> 4d if convolution
x_tensor = utils.to_tensor(x) if convolutional else x
current_input = x_tensor
```

with

```
# apply noise if denoising
x_ = (utils.corrupt(x) * corrupt_prob + x * (1 - corrupt_prob)) if denoising else x

# 2d -> 4d if convolution
x_tensor = utils.to_tensor(x_) if convolutional else x_
current_input = x_tensor
```

The temporary `x_` was introduced to keep the original input `x` intact for the loss function.