### PR TITLE
Proper print function for python 2.7

### DIFF
--- a/session-1/libs/utils.py
+++ b/session-1/libs/utils.py
@@ -6,6 +6,7 @@ Parag K. Mital
 
 Copyright Parag K. Mital, June 2016.
 """
+from __future__ import print_function
 import matplotlib.pyplot as plt
 import tensorflow as tf
 import urllib

--- a/session-2/libs/utils.py
+++ b/session-2/libs/utils.py
@@ -6,6 +6,7 @@ Parag K. Mital
 
 Copyright Parag K. Mital, June 2016.
 """
+from __future__ import print_function
 import matplotlib.pyplot as plt
 import tensorflow as tf
 import urllib

--- a/session-3/libs/utils.py
+++ b/session-3/libs/utils.py
@@ -6,6 +6,7 @@ Parag K. Mital
 
 Copyright Parag K. Mital, June 2016.
 """
+from __future__ import print_function
 import matplotlib.pyplot as plt
 import tensorflow as tf
 import urllib

--- a/session-4/libs/stylenet.py
+++ b/session-4/libs/stylenet.py
@@ -6,6 +6,7 @@ Creative Applications of Deep Learning w/ Tensorflow.
 Kadenze, Inc.
 Copyright Parag K. Mital, June 2016.
 """
+from __future__ import print_function
 import tensorflow as tf
 import numpy as np
 import matplotlib.pyplot as plt

--- a/session-4/libs/utils.py
+++ b/session-4/libs/utils.py
@@ -6,6 +6,7 @@ Parag K. Mital
 
 Copyright Parag K. Mital, June 2016.
 """
+from __future__ import print_function
 import matplotlib.pyplot as plt
 import tensorflow as tf
 import urllib

--- a/session-5/libs/charrnn.py
+++ b/session-5/libs/charrnn.py
@@ -7,7 +7,7 @@ argparse
 better sound example/model
 prime with text input
 """
-
+from __future__ import print_function
 import tensorflow as tf
 import numpy as np
 import os

--- a/session-5/libs/stylenet.py
+++ b/session-5/libs/stylenet.py
@@ -6,6 +6,7 @@ Creative Applications of Deep Learning w/ Tensorflow.
 Kadenze, Inc.
 Copyright Parag K. Mital, June 2016.
 """
+from __future__ import print_function
 import tensorflow as tf
 import numpy as np
 import matplotlib.pyplot as plt

--- a/session-5/libs/utils.py
+++ b/session-5/libs/utils.py
@@ -6,6 +6,7 @@ Parag K. Mital
 
 Copyright Parag K. Mital, June 2016.
 """
+from __future__ import print_function
 import matplotlib.pyplot as plt
 import tensorflow as tf
 import urllib


### PR DESCRIPTION
The Python 2.7 print function does not support the end='\r' tag used in many of the files in the libs folder. This means that people on older python versions get an error when they try to import something... 

I fixed it in all files in the libs folder by adding the line from __future__ import print_function...
It would be good to add this line to the notebooks itself so people with an older python version don't get strange errors. 