### PR TITLE
Add --allow-root flag to notebook command in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ README.md  lecture-1.ipynb  libs  session-1.ipynb  tests
 Which you can use to launch jupyter like so:
 
 ```bash
-root@39c4441bcde8:/notebooks# jupyter notebook
+root@39c4441bcde8:/notebooks# jupyter notebook --allow-root
 [I 01:45:27.712 NotebookApp] [nb_conda_kernels] enabled, 2 kernels found
 [I 01:45:27.715 NotebookApp] Writing notebook server cookie secret to /root/.local/share/jupyter/runtime/notebook_cookie_secret
 [W 01:45:27.729 NotebookApp] WARNING: The notebook server is listening on all IP addresses and not using encryption. This is not recommended.


### PR DESCRIPTION
Without this flag, when running as root inside a Docker container, I got the following error:

```
[I 10:03:16.812 NotebookApp] Running the core application with no additional extensions or settings
[C 10:03:16.818 NotebookApp] Running as root is not recommended. Use --allow-root to bypass.
```